### PR TITLE
Range selection are now also triggered on mouse events without drag

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ Calendar-component is a UI component add-on for Vaadin 8.
 
 Moved to BETA stage and testing for stable release.
 
+### Version 2.0-BETA5
+- Change:   Range selection events are now also triggered on single clicks
+
 ### Version 2.0-BETA4
 - Change:   Vaadin version 8.4.0 for the demo
 - Fix:      [Issue#17] BasicBackwardHandler and BasicForewardHandler loop cycle fixed  

--- a/calendar-component-addon/pom.xml
+++ b/calendar-component-addon/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>org.vaadin.blackbluegl</groupId>
 	<artifactId>calendar-component</artifactId>
 	<packaging>jar</packaging>
-	<version>2.0-BETA4</version>
+	<version>2.0-BETA5</version>
 	<name>Calendar Add-on</name>
 
 	<prerequisites>

--- a/calendar-component-addon/src/main/java/org/vaadin/addon/calendar/client/ui/schedule/DateCell.java
+++ b/calendar-component-addon/src/main/java/org/vaadin/addon/calendar/client/ui/schedule/DateCell.java
@@ -641,8 +641,7 @@ public class DateCell extends FocusableComplexPanel
         setFocus(false);
 
         // Drag initialized?
-        int dragDistance = Math.abs(eventRangeStart - event.getY());
-        if (dragDistance > 0 && eventRangeStart >= 0) {
+        if (eventRangeStart >= 0) {
             Element main = getElement();
             if (eventRangeStart > eventRangeStop) {
                 if (eventRangeStop <= -1) {
@@ -651,6 +650,11 @@ public class DateCell extends FocusableComplexPanel
                 int temp = eventRangeStart;
                 eventRangeStart = eventRangeStop;
                 eventRangeStop = temp;
+            }
+
+            // This happens for single clicks without dragging on the calendar
+            if(eventRangeStart == eventRangeStop) {
+                handleEventRange(event);
             }
 
             NodeList<Node> nodes = main.getChildNodes();
@@ -706,6 +710,10 @@ public class DateCell extends FocusableComplexPanel
 
     @Override
     public void onMouseMove(MouseMoveEvent event) {
+        handleEventRange(event);
+    }
+
+    private void handleEventRange(final MouseEvent event) {
 
         if (event.getNativeButton() != NativeEvent.BUTTON_LEFT) {
             return;

--- a/calendar-component-demo/pom.xml
+++ b/calendar-component-demo/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>org.vaadin.blackbluegl</groupId>
 	<artifactId>calendar-component-demo</artifactId>
 	<packaging>war</packaging>
-	<version>2.0-BETA4</version>
+	<version>2.0-BETA5</version>
 	<name>Calendar Add-on :: Demo</name>
 
 	<prerequisites>

--- a/calendar-component-demo/src/main/webapp/VAADIN/themes/demo/addons.scss
+++ b/calendar-component-demo/src/main/webapp/VAADIN/themes/demo/addons.scss
@@ -1,7 +1,7 @@
 /* This file is automatically managed and will be overwritten from time to time. */
 /* Do not manually edit this file. */
 
-/* Provided by calendar-component-2.0-BETA4.jar */
+/* Provided by calendar-component-2.0-BETA5.jar */
 @import "../../../VAADIN/addons/calendar/calendar-addon.scss";
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>org.vaadin.blackbluegl</groupId>
 	<artifactId>calendar-component-root</artifactId>
 	<packaging>pom</packaging>
-	<version>2.0-BETA4</version>
+	<version>2.0-BETA5</version>
 	<name>Calendar Add-on :: Root</name>
 
 	<prerequisites>


### PR DESCRIPTION
Most calendar applications nowadays support some sort of single click on the calendar to create a calendar event. This small change adds support to single clicks on the calendar to create bookings. The demo was untouched but shows this new functionality.